### PR TITLE
Link to Windows installer for JALVIEW

### DIFF
--- a/docs/install_jalview.rst
+++ b/docs/install_jalview.rst
@@ -30,10 +30,9 @@ Alternatively, on macOS you can also download the installer ``.dmg`` file, open 
 Windows installation
 --------------------
 
-.. DANGER::
-    TODO
+Download the installer, find it in explorer, right-click to run it as administrator, and follow the instructiuons:
 
-We need some installation instructions, here
+- `JALVIEW installer for Windows <http://www.jalview.org/Web_Installers/InstData/Windows_Pure_64_Bit/NoVM/install-jalview.exe>`_
 
 
 .. _Bioconda: https://bioconda.github.io/


### PR DESCRIPTION
We're ignoring the larger download with a bundled Java VM.

We might be able to install it under the user's home directory without admin rights, but it seems simplest to explicitly run it as administrator (it does not prompt on its own - it just complains about permissions for the default folder).

